### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Potential fix for [https://github.com/pop/pop.github.io/security/code-scanning/1](https://github.com/pop/pop.github.io/security/code-scanning/1)

In general, the fix is to add an explicit `permissions:` block to the workflow or to the specific job, granting only the minimal scopes needed for the `GITHUB_TOKEN`. Since this job deploys a blog to the `gh-pages` branch via `shalzz/zola-deploy-action`, it needs to be able to push commits, which requires `contents: write`. It does not obviously need broader write access (like `issues`, `pull-requests`, etc.), so we should grant only `contents: write`.

The best minimal change without altering behavior is to add a `permissions:` block under the `build-deploy` job. This confines the change to the shown snippet and avoids assumptions about any other jobs that might exist in the file. We will set:

```yaml
permissions:
  contents: write
```

concretely under `build-deploy:` (same indentation level as `runs-on:`). No imports or additional definitions are required; this is a pure YAML configuration change in `.github/workflows/main.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
